### PR TITLE
fix(use-positioner): re-initialize positioner instance before render

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "typescript": "latest"
   },
   "dependencies": {
+    "@essentials/are-equal": "^1.1.0",
     "@essentials/memoize-one": "^1.1.0",
     "@essentials/one-key-map": "^1.2.0",
     "@essentials/request-timeout": "^1.3.0",

--- a/src/__snapshots__/index.test.tsx.snap
+++ b/src/__snapshots__/index.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`<Masonry> should update when the size of the window changes: Should dis
     </div>
     <div
       role="griditem"
-      style="top: 400px; left: 0px; width: 100px; writing-mode: horizontal-tb; position: absolute;"
+      style="width: 100px; position: absolute; writing-mode: horizontal-tb; top: 400px; left: 0px;"
     >
       <div
         style="width: 100%; height: 400px;"

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -379,6 +379,22 @@ describe('usePositioner()', () => {
     result.current.update([1, 204])
     expect(result.current.shortestColumn()).toBe(804)
   })
+
+  it('should create a new positioner when deps change', () => {
+    const {result, rerender} = renderHook(
+      ({deps, ...props}) => usePositioner(props, deps),
+      {
+        initialProps: {width: 1280, columnCount: 1, deps: [1]},
+      }
+    )
+
+    const initialPositioner = result.current
+    rerender({width: 1280, columnCount: 1, deps: [1]})
+    expect(result.current).toBe(initialPositioner)
+
+    rerender({width: 1280, columnCount: 1, deps: [2]})
+    expect(result.current).not.toBe(initialPositioner)
+  })
 })
 
 describe('useContainerPosition()', () => {
@@ -828,12 +844,18 @@ const FakeCard = ({data: {height}, index}): React.ReactElement => (
 // Simulate scroll events
 const scrollEvent = document.createEvent('Event')
 scrollEvent.initEvent('scroll', true, true)
-const scrollTo = (value): void => {
+
+const setScroll = (value): void => {
   Object.defineProperty(window, 'scrollY', {value, configurable: true})
+}
+
+const scrollTo = (value): void => {
+  setScroll(value)
   window.dispatchEvent(scrollEvent)
 }
+
 const resetScroll = (): void => {
-  scrollTo(0)
+  setScroll(0)
 }
 
 // Simulate window resize event
@@ -842,7 +864,7 @@ resizeEvent.initEvent('resize', true, true)
 const orientationEvent = document.createEvent('Event')
 orientationEvent.initEvent('orientationchange', true, true)
 
-const resizeTo = (width, height) => {
+const setWindowSize = (width, height): void => {
   Object.defineProperty(document.documentElement, 'clientWidth', {
     value: width,
     configurable: true,
@@ -851,11 +873,15 @@ const resizeTo = (width, height) => {
     value: height,
     configurable: true,
   })
+}
+
+const resizeTo = (width, height) => {
+  setWindowSize(width, height)
   window.dispatchEvent(resizeEvent)
 }
 
 const resetSize = () => {
-  resizeTo(1280, 720)
+  setWindowSize(1280, 720)
 }
 
 // performance.now mock

--- a/yarn.lock
+++ b/yarn.lock
@@ -1143,6 +1143,11 @@
   dependencies:
     find-up "^4.0.0"
 
+"@essentials/are-equal@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@essentials/are-equal/-/are-equal-1.1.0.tgz#f2a72710f0ed9f11177bbe9c2589c14dbf6860d7"
+  integrity sha512-RkgLGQMuw9NO2BJB4dIUKN8H9U0OftLBjM9zUTozFviaabf7vuEwC4UMrLJdufN5ku9SbY71aUk8OOhuGtmCUQ==
+
 "@essentials/benchmark@^1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@essentials/benchmark/-/benchmark-1.0.6.tgz#2a62efc783cfda2ab0aed00960140d791622632c"


### PR DESCRIPTION
Fixes an issue when `useMasonary` used stale positioner instance after the dependencies change.

It's critical when working with dynamic lists. The stale instance may contain nonexistent cells.

Following https://github.com/jaredLunde/masonic/issues/12#issuecomment-687042085.
