### PR TITLE
feat: positioner exposes `all` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,10 @@ export interface Positioner {
    * Returns the height of the shortest column in the grid
    */
   shortestColumn: () => number
+  /**
+   * Returns all `PositionerItem` items
+   */
+  all: () => PositionerItem[]
 }
 
 export interface PositionerItem {

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -395,6 +395,18 @@ describe('usePositioner()', () => {
     rerender({width: 1280, columnCount: 1, deps: [2]})
     expect(result.current).not.toBe(initialPositioner)
   })
+
+  it('should report items', () => {
+    const {result} = renderHook((props) => usePositioner(props), {
+      initialProps: {width: 1280},
+    })
+    const length = 100
+    for (let i = 0; i < length; i++) {
+      result.current.set(i, 200)
+    }
+    expect(result.current.size()).toBe(length)
+    expect(result.current.all()).toHaveLength(length)
+  })
 })
 
 describe('useContainerPosition()', () => {

--- a/src/use-positioner.ts
+++ b/src/use-positioner.ts
@@ -216,6 +216,9 @@ export const createPositioner = (
     size(): number {
       return intervalTree.size
     },
+    all(): PositionerItem[] {
+      return items
+    },
   }
 }
 
@@ -266,6 +269,10 @@ export interface Positioner {
    */
 
   shortestColumn: () => number
+  /**
+   * Returns all `PositionerItem` items
+   */
+  all: () => PositionerItem[]
 }
 
 export interface PositionerItem {


### PR DESCRIPTION
Fixes #88

> IMPORTANT: Please do not create a Pull Request without creating an issue first.
> **Any change needs to be discussed before proceeding.** Failure to do so may result
> in the rejection of the pull request.

## Thank you for contributing to Masonic

### Before submitting

Read the [CONTRIBUTING.md](https://github.com/jaredLunde/react-hook/blob/master/CONTRIBUTING.md) file and confirm that you're following
all of the guidelines

Yes, I've read them. Should I use "positioner" as a tag?

### Please provide enough information so that others can review your pull request

- What does this implement/fix? Explain your changes.
- Does this close any currently open issues?

This change includes an "all" API method to the usePositioner return object.
It simply returns "items" so the consuming code can iterate over the items in the tree.
This is different from the `range` API which requires scroll positions as input.

This pull-request closes: https://github.com/jaredLunde/masonic/issues/88

### Testing

Confirm that your pull request contains tests and that all existing tests pass.

I added a simple test and everything is passing. `yarn validate` passes.

### Closing issues

Put closes #XXXX in your comment to auto-close the issue that your PR fixes (if such).
