### PR TITLE
fix(use-positioner): column count calculation

### DIFF
--- a/src/use-positioner.ts
+++ b/src/use-positioner.ts
@@ -336,7 +336,7 @@ const getColumns = (
   gutter = 8,
   columnCount?: number
 ): [number, number] => {
-  columnCount = columnCount || Math.floor(width / (minimumWidth + gutter)) || 1;
+  columnCount = columnCount || Math.floor((width + gutter) / (minimumWidth + gutter)) || 1;
   const columnWidth = Math.floor(
     (width - gutter * (columnCount - 1)) / columnCount
   );


### PR DESCRIPTION
num of gutters = num of columns - 1. The previous logic uses num of gutters = num of columns which results in an incorrect number of columns.

i.e. let width = 845, gutter = 35, minWidth = 185.

width needed for 4 columns = (185 * 4) + (35 * 3) = 845

Previous logic results in 3 columns: `845 / (35 + 185) = 3.8....`
when in reality, there is exactly enough space for 4 columns: `(845 + 35) / (185 + 35)` = 4
Now results in exactly 4.

shows the issue and the fix:
https://codesandbox.io/s/masonic-inside-of-a-scrollable-div-example-forked-f1gjcj?file=/src/index.js:1059-1163

Closes https://github.com/jaredLunde/masonic/issues/109.

I'll look at tests later.