### PR TITLE
fix(use-masonry): should update when positioner changes

### DIFF
--- a/src/use-masonry.tsx
+++ b/src/use-masonry.tsx
@@ -187,7 +187,7 @@ export function useMasonry<Item>({
   React.useEffect(() => {
     if (needsFreshBatch) forceUpdate();
     // eslint-disable-next-line
-  }, [needsFreshBatch]);
+  }, [needsFreshBatch, positioner]);
 
   // gets the container style object based upon the estimated height and whether or not
   // the page is being scrolled


### PR DESCRIPTION
This pull request fixes an issue around grid invisibility when itemHeightEstimate is not accurate and items get mutated.

_The reason why this bug is present:_
When `itemHeightEstimate` is not accurate, there are multiple batches rendered one by one. When items get mutated, new positioner instance is created and it should be filled with entries describing all visible tiles. Unfortunately, it doesn't happen. `useMasonry` hook is stuck in stage 1 forever unless its parent updates triggering stage 2.

To update itself, `useMasonry` hook uses `useEffect` with `needsFreshBatch` dependency. When `needsFreshBatch` stays true between renders this hook isn't called. When positioner changes, there is a new instance of `setItemRef` function created, which is responsible for populating cache. Now, there is another update needed for stage 2 to take place. That's why adding positioner to `useEffect` dependencies fixes this issue - it causes another update.

My guess is when `itemHeightEstimate` is accurate, `needsFreshBatch` changes from `true` to `false` properly. That's why this bug isn't common.

_How it was fixed:_
`positioner` got added to dependency array of the force update effect. This leads to another update populating cache and trigger stage 2.

This pull request closes #112.
