### PR TITLE
feat(use-positioner): add maxColumnWidth property

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ const MasonryCard = ({ index, data: { id }, width }) => (
 An autosizing masonry grid that only renders items currently visible in the browser `window`. This
 component will change its column count to fit its container's width and will decide how many rows
 to render based upon the height of the browser `window`. To facilitate this, it uses [`useMasonry()`](#usemasonryoptions),
-[`usePositioner()`](#usepositioneroptions-deps), [`useResizeObserver()`](#useresizeobserverpositioner),  
+[`usePositioner()`](#usepositioneroptions-deps), [`useResizeObserver()`](#useresizeobserverpositioner),
 [`useContainerPosition()`](#usecontainerpositionelementref-deps), and [`useScroller()`](#usescrolleroffset-fps) under the hood.
 
 This is the "batteries included" option. It's the easiest way to get off and running with your app and a
@@ -176,6 +176,7 @@ Props for tuning the column width, count, and gutter of your component.
 | rowGutter      | `number` | Same as `columnGutter` | No        | This sets the vertical space between cells within a column in pixels.                                                                                                                                                                                                                |
 | columnCount    | `number` |                        | No        | By default, `Masonic` derives the column count from the `columnWidth` prop. However, in some situations it is nice to be able to override that behavior e.g. when creating a [`<List>`](#list).                                                                                      |
 | maxColumnCount | `number` |                        | No        | Limits the number of columns used by `Masonic`. Useful for implementing responsive layouts.                                                                                                                                                                                          |
+| maxColumnWidth | `number` |                        | No        | Limits the calculated width of columns rendered by `Masonic`.                                                                                                                                                                                                                        |
 
 **Grid container props**
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -435,6 +435,29 @@ describe("usePositioner()", () => {
     expect(result.current.columnWidth).toBe(418);
   });
 
+  it("should automatically derive column width when a maximum column width is defined", () => {
+    const { result, rerender } = renderHook((props) => usePositioner(props), {
+      initialProps: {
+        width: 1280,
+        columnCount: 4,
+        columnGutter: 10,
+        maxColumnWidth: 300,
+      },
+    });
+
+    expect(result.current.columnCount).toBe(4);
+    expect(result.current.columnWidth).toBe(300);
+
+    rerender({
+      width: 1280,
+      columnCount: 3,
+      columnGutter: 12,
+      maxColumnWidth: 300,
+    });
+    expect(result.current.columnCount).toBe(3);
+    expect(result.current.columnWidth).toBe(300);
+  });
+
   it("should automatically derive column width when a maximum column count is defined", () => {
     const { result, rerender } = renderHook((props) => usePositioner(props), {
       initialProps: {

--- a/src/masonry.tsx
+++ b/src/masonry.tsx
@@ -68,6 +68,7 @@ export interface MasonryProps<Item>
       | "rowGutter"
       | "columnCount"
       | "maxColumnCount"
+      | "maxColumnWidth"
     > {
   /**
    * Scrolls to a given index within the grid. The grid will re-scroll

--- a/src/use-positioner.ts
+++ b/src/use-positioner.ts
@@ -16,6 +16,7 @@ import { createIntervalTree } from "./interval-tree";
  * @param options.rowGutter
  * @param options.columnCount
  * @param options.maxColumnCount
+ * @param options.maxColumnWidth
  */
 export function usePositioner(
   {
@@ -25,6 +26,7 @@ export function usePositioner(
     rowGutter,
     columnCount,
     maxColumnCount,
+    maxColumnWidth,
   }: UsePositionerOptions,
   deps: React.DependencyList = emptyArr
 ): Positioner {
@@ -34,7 +36,8 @@ export function usePositioner(
       columnWidth,
       columnGutter,
       columnCount,
-      maxColumnCount
+      maxColumnCount,
+      maxColumnWidth
     );
     return createPositioner(
       computedColumnCount,
@@ -55,6 +58,7 @@ export function usePositioner(
     rowGutter,
     columnCount,
     maxColumnCount,
+    maxColumnWidth,
   ];
   const prevOpts = React.useRef(opts);
   const optsChanged = !opts.every((item, i) => prevOpts.current[i] === item);
@@ -105,6 +109,10 @@ export interface UsePositionerOptions {
    * @default 200
    */
   columnWidth?: number;
+  /**
+   * The maximum column width. Calculated column widths will be capped at this value.
+   */
+  maxColumnWidth?: number;
   /**
    * This sets the horizontal space between grid columns in pixels. If `rowGutter` is not set, this
    * also sets the vertical space between cells within a column in pixels.
@@ -349,7 +357,8 @@ const getColumns = (
   minimumWidth = 0,
   gutter = 8,
   columnCount?: number,
-  maxColumnCount?: number
+  maxColumnCount?: number,
+  maxColumnWidth?: number
 ): [number, number] => {
   columnCount =
     columnCount ||
@@ -358,9 +367,15 @@ const getColumns = (
       maxColumnCount || Infinity
     ) ||
     1;
-  const columnWidth = Math.floor(
+  let columnWidth = Math.floor(
     (width - gutter * (columnCount - 1)) / columnCount
   );
+
+  // Cap the column width if maxColumnWidth is specified
+  if (maxColumnWidth !== undefined && columnWidth > maxColumnWidth) {
+    columnWidth = maxColumnWidth;
+  }
+
   return [columnWidth, columnCount];
 };
 


### PR DESCRIPTION
Apologies for not creating an issue first. I thought this would be a straightforward enough change to discuss here.

### Please provide enough information so that others can review your pull request

- Adds a `maxColumnWidth` prop to the `Masonry` component, to cap the calculated width of columns.
- Grid becomes left-aligned as a side effect. 
  - I considered trying to center the grid using a calculated `left` amount, but didn’t want to disrupt the code too much. For our use case, a left aligned grid is fine. Happy to receive pointers on ways to center the grid.

### Testing

Tests added and all passing.
